### PR TITLE
feat: add WebTransport support

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,14 +17,15 @@
     "@libp2p/devtools-metrics": "^1.1.8",
     "@libp2p/identify": "^3.0.10",
     "@libp2p/peer-id": "^5.0.7",
+    "@libp2p/webtransport": "^5.0.22",
     "@multiformats/multiaddr": "^12.3.1",
     "helia": "^5.1.0",
     "multiformats": "^13.3.1"
   },
   "devDependencies": {
-    "typescript": "^5.6.3",
     "@types/node": "^22.9.0",
     "esbuild": "^0.24.0",
-    "rimraf": "^6.0.1"
+    "rimraf": "^6.0.1",
+    "typescript": "^5.6.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,9 +1,10 @@
-import { multiaddr } from '@multiformats/multiaddr'
-import { peerIdFromString } from '@libp2p/peer-id'
-import { createHelia, DefaultLibp2pServices, HeliaLibp2p, libp2pDefaults } from 'helia'
-import { base58btc } from 'multiformats/bases/base58'
 import { devToolsMetrics } from '@libp2p/devtools-metrics'
 import { identify } from '@libp2p/identify'
+import { peerIdFromString } from '@libp2p/peer-id'
+import { webTransport } from '@libp2p/webtransport'
+import { multiaddr } from '@multiformats/multiaddr'
+import { createHelia, DefaultLibp2pServices, HeliaLibp2p, libp2pDefaults } from 'helia'
+import { base58btc } from 'multiformats/bases/base58'
 import type { Libp2p } from '@libp2p/interface'
 
 const App = async () => {
@@ -170,7 +171,6 @@ const App = async () => {
 
   showStatus('Creating Helia node')
 
-
   const libp2p = libp2pDefaults()
   libp2p.addresses = {}
   libp2p.peerDiscovery = [] // don't connect to the bootstrap nodes by default
@@ -178,6 +178,8 @@ const App = async () => {
   libp2p.services.identify = identify({
     runOnConnectionOpen: false
   })
+  // add webtransport transport
+  libp2p.transports?.push(webTransport())
 
   const helia = await createHelia<Libp2p<DefaultLibp2pServices>>({
     libp2p


### PR DESCRIPTION
WebTransport support was [removed from Helia](https://github.com/ipfs/helia/pull/674) due to the [various browser bugs](https://github.com/libp2p/js-libp2p/issues/2572) that prevent it being reliable.

This PR adds support back in so we can test changes to browser support over time.